### PR TITLE
Fixed bug in utilities.py when reading MDL Molfile with properties block

### DIFF
--- a/chemspax/utilities.py
+++ b/chemspax/utilities.py
@@ -286,6 +286,8 @@ def read_connectivity_from_mol_file(source_file, n_atoms):
     connectivity_list = []
     # each item has 3 spaces, based on this the item can be loaded in a dataframe
     for line in connectivity_data:
+        if line[:3].replace(' ', '') == 'M': # This prevents the program to crash over a properties block in the end
+            break
         idx1 = int(line[:3].replace(' ', ''))
         idx2 = int(line[3:6].replace(' ', ''))
         bond = int(line[6:9].replace(' ', ''))


### PR DESCRIPTION
If a MDL Molfile had a properties block just before the end line (https://en.wikipedia.org/wiki/Chemical_table_file#Molfile) ChemSpaX crashed since it thought that this was part of the bond block. All property block lines should start with an 'M' and since there is no element that has as symbol 'M' I made a fix that stops reading the bonds as soon as 'M' is found as the first character in the line. 